### PR TITLE
get average voltage for single phase

### DIFF
--- a/emlite_mediator/emlite/messages/emlite_response.ksy
+++ b/emlite_mediator/emlite/messages/emlite_response.ksy
@@ -29,6 +29,7 @@ seq:
         "object_id_type::hardware_version": hardware_rec
         "object_id_type::csq_net_op": csq_net_op_rec
         "object_id_type::instantaneous_voltage": instantaneous_voltage_rec
+        "object_id_type::average_voltage": average_voltage_rec
         "object_id_type::prepay_enabled_flag": prepay_enabled_rec
         "object_id_type::prepay_balance": prepay_balance_rec
         "object_id_type::three_phase_instantaneous_voltage_l1": three_phase_instantaneous_voltage_l1_rec
@@ -73,6 +74,10 @@ types:
       - id: csq
         type: b5
   instantaneous_voltage_rec:
+    seq:
+      - id: voltage
+        type: u2le
+  average_voltage_rec:
     seq:
       - id: voltage
         type: u2le

--- a/emlite_mediator/emlite/messages/emlite_response.py
+++ b/emlite_mediator/emlite/messages/emlite_response.py
@@ -91,6 +91,10 @@ class EmliteResponse(ReadWriteKaitaiStruct):
             pass
             self.response = EmliteResponse.InstantaneousVoltageRec(self._io, self, self._root)
             self.response._read()
+        elif _on == EmliteResponse.ObjectIdType.average_voltage:
+            pass
+            self.response = EmliteResponse.AverageVoltageRec(self._io, self, self._root)
+            self.response._read()
         elif _on == EmliteResponse.ObjectIdType.prepay_balance:
             pass
             self.response = EmliteResponse.PrepayBalanceRec(self._io, self, self._root)
@@ -133,6 +137,9 @@ class EmliteResponse(ReadWriteKaitaiStruct):
         elif _on == EmliteResponse.ObjectIdType.instantaneous_voltage:
             pass
             self.response._fetch_instances()
+        elif _on == EmliteResponse.ObjectIdType.average_voltage:
+            pass
+            self.response._fetch_instances()
         elif _on == EmliteResponse.ObjectIdType.prepay_balance:
             pass
             self.response._fetch_instances()
@@ -169,6 +176,9 @@ class EmliteResponse(ReadWriteKaitaiStruct):
             pass
             self.response._write__seq(self._io)
         elif _on == EmliteResponse.ObjectIdType.instantaneous_voltage:
+            pass
+            self.response._write__seq(self._io)
+        elif _on == EmliteResponse.ObjectIdType.average_voltage:
             pass
             self.response._write__seq(self._io)
         elif _on == EmliteResponse.ObjectIdType.prepay_balance:
@@ -225,6 +235,12 @@ class EmliteResponse(ReadWriteKaitaiStruct):
             if self.response._parent != self:
                 raise kaitaistruct.ConsistencyError(u"response", self.response._parent, self)
         elif _on == EmliteResponse.ObjectIdType.instantaneous_voltage:
+            pass
+            if self.response._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"response", self.response._root, self._root)
+            if self.response._parent != self:
+                raise kaitaistruct.ConsistencyError(u"response", self.response._parent, self)
+        elif _on == EmliteResponse.ObjectIdType.average_voltage:
             pass
             if self.response._root != self._root:
                 raise kaitaistruct.ConsistencyError(u"response", self.response._root, self._root)
@@ -320,6 +336,29 @@ class EmliteResponse(ReadWriteKaitaiStruct):
         def _write__seq(self, io=None):
             super(EmliteResponse.PrepayBalanceRec, self)._write__seq(io)
             self._io.write_s4le(self.balance)
+
+
+        def _check(self):
+            pass
+
+
+    class AverageVoltageRec(ReadWriteKaitaiStruct):
+        def __init__(self, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+
+        def _read(self):
+            self.voltage = self._io.read_u2le()
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(EmliteResponse.AverageVoltageRec, self)._write__seq(io)
+            self._io.write_u2le(self.voltage)
 
 
         def _check(self):

--- a/emlite_mediator/mediator/client.py
+++ b/emlite_mediator/mediator/client.py
@@ -61,6 +61,11 @@ class EmliteMediatorClient():
         logger.info('received instantaneous voltage', voltage=data.voltage)
         return data.voltage
 
+    def average_voltage(self) -> float:
+        data = self._read_element(ObjectIdEnum.average_voltage)
+        logger.info('received average voltage', voltage=data.voltage)
+        return data.voltage
+
     def prepay_enabled(self) -> bool:
         data = self._read_element(ObjectIdEnum.prepay_enabled_flag)
         enabled: bool = data.enabled_flag == 1

--- a/emlite_mediator/mediator/grpc/client.py
+++ b/emlite_mediator/mediator/grpc/client.py
@@ -61,4 +61,5 @@ class EmliteMediatorGrpcClient():
 if __name__ == '__main__':
     client = EmliteMediatorGrpcClient()
     client.read_element(ObjectIdEnum.instantaneous_voltage)
+    client.read_element(ObjectIdEnum.average_voltage)
     # client.send_message(bytes.fromhex('0160010000'))

--- a/emlite_mediator/sync/syncer_voltage.py
+++ b/emlite_mediator/sync/syncer_voltage.py
@@ -16,7 +16,9 @@ class SyncerVoltage(SyncerBase):
                        '3p_voltage_l2': v2,
                        '3p_voltage_l3': v3}
         else:
-            voltage = self.emlite_client.instantaneous_voltage()
-            metrics = {'voltage': voltage}
+            instantaneous_voltage = self.emlite_client.instantaneous_voltage()
+            average_voltage = self.emlite_client.average_voltage()
+            metrics = {'average_voltage': average_voltage,
+                       'instantaneous_voltage': instantaneous_voltage}
 
         return UpdatesTuple(metrics, None)

--- a/tests/emlite_mediator/emlite/messages/test_emlite_response.py
+++ b/tests/emlite_mediator/emlite/messages/test_emlite_response.py
@@ -55,8 +55,12 @@ class TestEmliteResponse(unittest.TestCase):
         self.assertEqual(response.balance, -33326400) # -333.264 GBP
         
     def test_instantaneous_voltage(self):
-        response = self._deserialize(EmliteResponse.ObjectIdType.instantaneous_voltage, '5209')
-        self.assertEqual(response.voltage, 2386) # 238.6
+        response = self._deserialize(EmliteResponse.ObjectIdType.instantaneous_voltage, 'f300')
+        self.assertEqual(response.voltage, 243) # 243
+
+    def test_average_voltage(self):
+        response = self._deserialize(EmliteResponse.ObjectIdType.average_voltage, 'be00')
+        self.assertEqual(response.voltage, 190) # 190
 
     def test_threephase_voltage(self):
         response = self._deserialize(EmliteResponse.ObjectIdType.three_phase_instantaneous_voltage_l1, '5209')


### PR DESCRIPTION
Adds syncing of average_voltage however all are returning 0 currently.

Discussion in Discord stared - this might not be supported

Related DB PR: https://github.com/cepro/simt-supabase/pull/3