### PR TITLE
EMOP: handle profile log messages

### DIFF
--- a/emlite_mediator/emlite/messages/emlite_data.ksy
+++ b/emlite_mediator/emlite/messages/emlite_data.ksy
@@ -5,30 +5,70 @@ meta:
 
 doc: |
   EMOP data field is embedded in each EMOP frame (see emlite_frame.ksy).
-  It contains a 3 byte object id (Obi) and a payload. The Obi identifies what
-  the data in the payload relates to. A number of Obis and corresponding data
-  are defined in the document "Meter and Smart Module Obis Commands iss1.5.pdf".
+  Most (see default_rec) contain a 3 byte object id (Obi) and a payload.
+  The Obi identifies what the data in the payload relates to. A number of
+  Obis and corresponding payloads are defined in the document "Meter and 
+  Smart Module Obis Commands iss1.5.pdf".
 
 params:
   - id: len_data
     type: u1
-    doc: Length of the payload field.
+    doc: Length of the data field.
 
 seq:
   - id: format
-    contents: [0x01]
-  - id: object_id
-    size: 3
-    # ideally would use enum from `emlite_message.object_id_type` here
-    # but there is no u3 so how to make it work with u4?
-    # enum: object_id_type
-  - id: read_write
     type: u1
-    enum: read_write_flags
-  - id: payload
-    size: len_data - 5
+    enum: record_format
+  - id: message
+    type:
+      switch-on: format
+      cases:
+        "record_format::default": default_rec(len_data)
+        "record_format::profile_log_1": profile_log_rec(len_data)
+        "record_format::profile_log_2": profile_log_rec(len_data)
+
+types:
+  default_rec:
+    doc: Default emlite data format (format 0x01) - most messages use this format
+    params:
+      - id: len_data
+        type: u1
+        doc: Length of the data field.
+    seq:
+      - id: object_id
+        size: 3
+        doc: |
+          ideally would use enum from `emlite_message.object_id_type` here
+          but there is no u3 so how to make it work with u4?
+          enum: object_id_type
+      - id: read_write
+        type: u1
+        enum: read_write_flags
+      - id: payload
+        size: len_data - 5
+
+  profile_log_rec:
+    doc: Profile log messages use this format (formats 0x03 and 0x04)
+    params:
+      - id: len_data
+        type: u1
+        doc: Length of the payload bytes.
+    seq:
+      - id: timestamp
+        type: u4le
+        doc: Timestamp to read the profile log from
+      - id: response_payload
+        size: 80
+        if: len_data > 5
+        doc: |
+          Response only data - when the data field is > 5 bytes of data which
+          is the size of the request. The size should then be 80 bytes.
 
 enums:
   read_write_flags:
     0x00: read
     0x01: write
+  record_format:
+    1: default
+    3: profile_log_1
+    4: profile_log_2

--- a/emlite_mediator/emlite/messages/emlite_data.py
+++ b/emlite_mediator/emlite/messages/emlite_data.py
@@ -10,14 +10,20 @@ if getattr(kaitaistruct, 'API_VERSION', (0, 9)) < (0, 9):
 
 class EmliteData(ReadWriteKaitaiStruct):
     """EMOP data field is embedded in each EMOP frame (see emlite_frame.ksy).
-    It contains a 3 byte object id (Obi) and a payload. The Obi identifies what
-    the data in the payload relates to. A number of Obis and corresponding data
-    are defined in the document "Meter and Smart Module Obis Commands iss1.5.pdf".
+    Most (see default_rec) contain a 3 byte object id (Obi) and a payload.
+    The Obi identifies what the data in the payload relates to. A number of
+    Obis and corresponding payloads are defined in the document "Meter and 
+    Smart Module Obis Commands iss1.5.pdf".
     """
 
     class ReadWriteFlags(Enum):
         read = 0
         write = 1
+
+    class RecordFormat(Enum):
+        default = 1
+        profile_log_1 = 3
+        profile_log_2 = 4
     def __init__(self, len_data, _io=None, _parent=None, _root=None):
         self._io = _io
         self._parent = _parent
@@ -25,40 +31,151 @@ class EmliteData(ReadWriteKaitaiStruct):
         self.len_data = len_data
 
     def _read(self):
-        self.format = self._io.read_bytes(1)
-        if not (self.format == b"\x01"):
-            raise kaitaistruct.ValidationNotEqualError(b"\x01", self.format, self._io, u"/seq/0")
-        self.object_id = self._io.read_bytes(3)
-        self.read_write = KaitaiStream.resolve_enum(EmliteData.ReadWriteFlags, self._io.read_u1())
-        self.payload = self._io.read_bytes((self.len_data - 5))
+        self.format = KaitaiStream.resolve_enum(EmliteData.RecordFormat, self._io.read_u1())
+        _on = self.format
+        if _on == EmliteData.RecordFormat.default:
+            pass
+            self.message = EmliteData.DefaultRec(self.len_data, self._io, self, self._root)
+            self.message._read()
+        elif _on == EmliteData.RecordFormat.profile_log_1:
+            pass
+            self.message = EmliteData.ProfileLogRec(self.len_data, self._io, self, self._root)
+            self.message._read()
+        elif _on == EmliteData.RecordFormat.profile_log_2:
+            pass
+            self.message = EmliteData.ProfileLogRec(self.len_data, self._io, self, self._root)
+            self.message._read()
 
 
     def _fetch_instances(self):
         pass
+        _on = self.format
+        if _on == EmliteData.RecordFormat.default:
+            pass
+            self.message._fetch_instances()
+        elif _on == EmliteData.RecordFormat.profile_log_1:
+            pass
+            self.message._fetch_instances()
+        elif _on == EmliteData.RecordFormat.profile_log_2:
+            pass
+            self.message._fetch_instances()
 
 
     def _write__seq(self, io=None):
         super(EmliteData, self)._write__seq(io)
-        self._io.write_bytes(self.format)
-        self._io.write_bytes(self.object_id)
-        self._io.write_u1(self.read_write.value)
-        self._io.write_bytes(self.payload)
+        self._io.write_u1(self.format.value)
+        _on = self.format
+        if _on == EmliteData.RecordFormat.default:
+            pass
+            self.message._write__seq(self._io)
+        elif _on == EmliteData.RecordFormat.profile_log_1:
+            pass
+            self.message._write__seq(self._io)
+        elif _on == EmliteData.RecordFormat.profile_log_2:
+            pass
+            self.message._write__seq(self._io)
 
 
     def _check(self):
         pass
-        if (len(self.format) != 1):
-            raise kaitaistruct.ConsistencyError(u"format", len(self.format), 1)
-        if not (self.format == b"\x01"):
-            raise kaitaistruct.ValidationNotEqualError(b"\x01", self.format, self._io, u"/seq/0")
-        if (len(self.object_id) != 3):
-            raise kaitaistruct.ConsistencyError(u"object_id", len(self.object_id), 3)
-        if (len(self.payload) != (self.len_data - 5)):
-            raise kaitaistruct.ConsistencyError(u"payload", len(self.payload), (self.len_data - 5))
+        _on = self.format
+        if _on == EmliteData.RecordFormat.default:
+            pass
+            if self.message._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"message", self.message._root, self._root)
+            if self.message._parent != self:
+                raise kaitaistruct.ConsistencyError(u"message", self.message._parent, self)
+            if (self.message.len_data != self.len_data):
+                raise kaitaistruct.ConsistencyError(u"message", self.message.len_data, self.len_data)
+        elif _on == EmliteData.RecordFormat.profile_log_1:
+            pass
+            if self.message._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"message", self.message._root, self._root)
+            if self.message._parent != self:
+                raise kaitaistruct.ConsistencyError(u"message", self.message._parent, self)
+            if (self.message.len_data != self.len_data):
+                raise kaitaistruct.ConsistencyError(u"message", self.message.len_data, self.len_data)
+        elif _on == EmliteData.RecordFormat.profile_log_2:
+            pass
+            if self.message._root != self._root:
+                raise kaitaistruct.ConsistencyError(u"message", self.message._root, self._root)
+            if self.message._parent != self:
+                raise kaitaistruct.ConsistencyError(u"message", self.message._parent, self)
+            if (self.message.len_data != self.len_data):
+                raise kaitaistruct.ConsistencyError(u"message", self.message.len_data, self.len_data)
 
-    # NOTE: Following, not generated, manually added, TODO: replace with a subclass or wrapper that ads this
-    def __str__(self):
-        return (
-            f"EmliteData(object_id={self.object_id.hex()},rw={self.read_write.value},"
-            f"payload=[{self.payload.hex()}])"
-        )
+    class DefaultRec(ReadWriteKaitaiStruct):
+        """Default emlite data format (format 0x01) - most messages use this format."""
+        def __init__(self, len_data, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+            self.len_data = len_data
+
+        def _read(self):
+            self.object_id = self._io.read_bytes(3)
+            self.read_write = KaitaiStream.resolve_enum(EmliteData.ReadWriteFlags, self._io.read_u1())
+            self.payload = self._io.read_bytes((self.len_data - 5))
+
+
+        def _fetch_instances(self):
+            pass
+
+
+        def _write__seq(self, io=None):
+            super(EmliteData.DefaultRec, self)._write__seq(io)
+            self._io.write_bytes(self.object_id)
+            self._io.write_u1(self.read_write.value)
+            self._io.write_bytes(self.payload)
+
+
+        def _check(self):
+            pass
+            if (len(self.object_id) != 3):
+                raise kaitaistruct.ConsistencyError(u"object_id", len(self.object_id), 3)
+            if (len(self.payload) != (self.len_data - 5)):
+                raise kaitaistruct.ConsistencyError(u"payload", len(self.payload), (self.len_data - 5))
+
+
+    class ProfileLogRec(ReadWriteKaitaiStruct):
+        """Profile log messages use this format (formats 0x03 and 0x04)."""
+        def __init__(self, len_data, _io=None, _parent=None, _root=None):
+            self._io = _io
+            self._parent = _parent
+            self._root = _root
+            self.len_data = len_data
+
+        def _read(self):
+            self.timestamp = self._io.read_u4le()
+            if (self.len_data > 5):
+                pass
+                self.response_payload = self._io.read_bytes(80)
+
+
+
+        def _fetch_instances(self):
+            pass
+            if (self.len_data > 5):
+                pass
+
+
+
+        def _write__seq(self, io=None):
+            super(EmliteData.ProfileLogRec, self)._write__seq(io)
+            self._io.write_u4le(self.timestamp)
+            if (self.len_data > 5):
+                pass
+                self._io.write_bytes(self.response_payload)
+
+
+
+        def _check(self):
+            pass
+            if (self.len_data > 5):
+                pass
+                if (len(self.response_payload) != 80):
+                    raise kaitaistruct.ConsistencyError(u"response_payload", len(self.response_payload), 80)
+
+
+
+

--- a/emlite_mediator/emlite/messages/emlite_message.ksy
+++ b/emlite_mediator/emlite/messages/emlite_message.ksy
@@ -224,13 +224,14 @@ types:
         encoding: ASCII
   firmware_rec:
     seq:
-      # single phase meters: return 4 bytes ascii string
-      # three phase meters: return 2 bytes with meaning not yet known
-      # therefore we just get variable length bytes here and let the client
-      # try decode it based on length
       - id: version_bytes
         type: u1
         repeat: eos
+        doc: |
+          single phase meters: return 4 bytes ascii string
+          three phase meters: return 2 bytes with meaning not yet known
+          therefore we just get variable length bytes here and let the client
+          try decode it based on length
   time_rec:
     seq:
       - id: year

--- a/emlite_mediator/mediator/grpc/server.py
+++ b/emlite_mediator/mediator/grpc/server.py
@@ -2,6 +2,7 @@ import os
 import signal
 import sys
 import time
+import traceback
 from concurrent import futures
 from datetime import datetime, timedelta
 
@@ -77,6 +78,7 @@ class EmliteMediatorServicer(EmliteMediatorServiceServicer):
             self.log.info("sendRawMessage response", payload=rsp_payload.hex())
             return SendRawMessageReply(response=rsp_payload)
         except Exception as e:
+            traceback.print_exc()
             self._handle_failure(e, "sendRawMessage", context)
             return SendRawMessageReply()
 
@@ -114,7 +116,7 @@ class EmliteMediatorServicer(EmliteMediatorServiceServicer):
             self._handle_failure(e, "writeElement", context)
             return WriteElementReply()
 
-    def _handle_failure(self, exception, call_name, context):
+    def _handle_failure(self, exception: Exception, call_name: str, context):
         if exception.__class__.__name__.startswith("RetryError"):
             self.log.warn(
                 "Failed to connect to meter after a number of retries",

--- a/tests/emlite_mediator/emlite/messages/test_emlite_data.py
+++ b/tests/emlite_mediator/emlite/messages/test_emlite_data.py
@@ -1,35 +1,89 @@
 import unittest
+from datetime import datetime
 
+from kaitaistruct import BytesIO, KaitaiStream
+
+from emlite_mediator.emlite.emlite_util import (
+    emop_datetime_to_epoch_seconds,
+    emop_epoch_seconds_to_datetime,
+)
 from emlite_mediator.emlite.messages.emlite_data import EmliteData
-from kaitaistruct import KaitaiStream, BytesIO
+
+PROFILE_LOG_1_RESPONSE_HEX = (
+    # format byte - profile log 1
+    "03"
+    +
+    # timestamp
+    "0008bb2d"
+    +
+    # 80 byte profile log response data
+    "60d0b02d0100f00600004507000068d7b02d0080f00600004507000070deb02d0080f00600004507000078e5b02d0080f00600004507000080ecb02d0080f00600004507000034000000000000000000"
+)
+
+PROFILE_LOG_1_RESPONSE_DATETIME = datetime(2024, 4, 24, 0, 0, 0)
+
 
 class TestEmliteDataField(unittest.TestCase):
-    def test_deserialise(self):
+    def test_deserialise_format_default(self):
         # 7E15C06F0093000018B0010100020100333032309DBD
         data_hex = "010002010033303230"
         data_bytes = bytearray.fromhex(data_hex)
-        
+
         data = EmliteData(len(data_bytes), KaitaiStream(BytesIO(data_bytes)))
         data._read()
 
         self.assertEqual(data.len_data, len(data_bytes))
-        self.assertEqual(data.read_write, EmliteData.ReadWriteFlags.read)
-        self.assertEqual(data.format, b'\x01')
-        self.assertEqual(data.object_id, b'\x00\x02\x01')
-        self.assertEqual(data.payload, data_bytes[5:])
+        self.assertEqual(data.format, EmliteData.RecordFormat.default)
+        self.assertEqual(data.message.object_id, b"\x00\x02\x01")
+        self.assertEqual(data.message.read_write, EmliteData.ReadWriteFlags.read)
+        self.assertEqual(data.message.payload, data_bytes[5:])
 
-    def test_serialise(self):
+    def test_serialise_format_default(self):
         field_len = 8
 
+        message_field = EmliteData.DefaultRec(field_len)
+        message_field.object_id = b"\x60\x01\x00"  # get serial obj id
+        message_field.read_write = EmliteData.ReadWriteFlags.read
+        message_field.payload = b"\xff\x00\xaa"  # some arbitrary payload
+
         data_field = EmliteData(field_len)
-        data_field.format = b'\x01'
-        data_field.object_id = b'\x60\x01\x00' # get serial obj id
-        data_field.read_write = EmliteData.ReadWriteFlags.read
-        data_field.payload = b'\xff\x00\xaa'   # some arbitrary payload
+        data_field.format = EmliteData.RecordFormat.default
+        data_field.message = message_field
 
         _io = KaitaiStream(BytesIO(bytearray(field_len)))
         data_field._write(_io)
         data_field_bytes = _io.to_byte_array()
 
-        self.assertEqual(data_field_bytes.hex(), '0160010000ff00aa')
+        self.assertEqual(data_field_bytes.hex(), "0160010000ff00aa")
 
+    def test_deserialise_format_profile_log(self):
+        data_bytes = bytearray.fromhex(PROFILE_LOG_1_RESPONSE_HEX)
+        data = EmliteData(len(data_bytes), KaitaiStream(BytesIO(data_bytes)))
+        data._read()
+
+        self.assertEqual(data.len_data, len(data_bytes))
+        self.assertEqual(data.format, EmliteData.RecordFormat.profile_log_1)
+        self.assertEqual(
+            emop_epoch_seconds_to_datetime(data.message.timestamp),
+            PROFILE_LOG_1_RESPONSE_DATETIME,
+        )
+        self.assertEqual(data.message.response_payload, data_bytes[5:])
+
+    def test_serialise_format_profile_log(self):
+        field_len = 85
+
+        message_field = EmliteData.ProfileLogRec(field_len)
+        message_field.timestamp = emop_datetime_to_epoch_seconds(
+            PROFILE_LOG_1_RESPONSE_DATETIME
+        )
+        message_field.response_payload = bytes.fromhex(PROFILE_LOG_1_RESPONSE_HEX)[5:]
+
+        data_field = EmliteData(field_len)
+        data_field.format = EmliteData.RecordFormat.profile_log_1
+        data_field.message = message_field
+
+        _io = KaitaiStream(BytesIO(bytearray(field_len)))
+        data_field._write(_io)
+        data_field_bytes = _io.to_byte_array()
+
+        self.assertEqual(data_field_bytes.hex(), PROFILE_LOG_1_RESPONSE_HEX)

--- a/tests/emlite_mediator/emlite/messages/test_emlite_frame.py
+++ b/tests/emlite_mediator/emlite/messages/test_emlite_frame.py
@@ -1,16 +1,15 @@
-import crcmod.predefined
 import unittest
 
-from kaitaistruct import KaitaiStream, BytesIO
+import crcmod.predefined
+from kaitaistruct import BytesIO, KaitaiStream
 
-from emlite_mediator.emlite.messages.emlite_frame import EmliteFrame
 from emlite_mediator.emlite.messages.emlite_data import EmliteData
+from emlite_mediator.emlite.messages.emlite_frame import EmliteFrame
 
-crc16 = crcmod.predefined.mkCrcFun('crc-ccitt-false')
+crc16 = crcmod.predefined.mkCrcFun("crc-ccitt-false")
 
 
 class TestEmliteFrame(unittest.TestCase):
-
     def test_deserialise_response(self):
         frame_hex = "7E15C06F0093000018B0010100020100333032309DBD"
         frame_bytes = bytearray.fromhex(frame_hex)
@@ -19,13 +18,13 @@ class TestEmliteFrame(unittest.TestCase):
         frame._read()
         frame_len = len(frame_bytes) - 1
 
-        self.assertEqual(frame.frame_delimeter, b'\x7e')
+        self.assertEqual(frame.frame_delimeter, b"\x7e")
         self.assertEqual(frame.frame_length, frame_len)
 
-        self.assertEqual(frame.destination_device_type, b'\xc0')
-        self.assertEqual(frame.destination_address, b'o\x00\x93')
-        self.assertEqual(frame.source_device_type, b'\x00')
-        self.assertEqual(frame.source_address, b'\x00\x18\xb0')
+        self.assertEqual(frame.destination_device_type, b"\xc0")
+        self.assertEqual(frame.destination_address, b"o\x00\x93")
+        self.assertEqual(frame.source_device_type, b"\x00")
+        self.assertEqual(frame.source_address, b"\x00\x18\xb0")
 
         self.assertEqual(frame.seq_num, 1)
         self.assertEqual(frame.ack_nak_code, EmliteFrame.AckNakCodes.ok)
@@ -35,27 +34,32 @@ class TestEmliteFrame(unittest.TestCase):
 
         data_field = frame.data
         self.assertEqual(data_field.len_data, len_data)
-        self.assertEqual(data_field.format, b'\x01')
-        self.assertEqual(data_field.payload,
-                         frame_bytes[16:len(frame_bytes)-2])
+        self.assertEqual(data_field.format, EmliteData.RecordFormat.default)
+        self.assertEqual(
+            data_field.message.payload, frame_bytes[16 : len(frame_bytes) - 2]
+        )
 
         self.assertEqual(frame.crc16, frame_bytes[-2:])
 
     def test_serialise_request_no_payload(self):
         req_frame = EmliteFrame()
 
-        req_frame.frame_delimeter = b'\x7e'
+        req_frame.frame_delimeter = b"\x7e"
         req_frame.control = 5
-        req_frame.destination_device_type = b'\x00'
-        req_frame.destination_address = b'\x00\x00\x00'
-        req_frame.source_device_type = b'\x00'
-        req_frame.source_address = int(2207298).to_bytes(3, byteorder='big')
+        req_frame.destination_device_type = b"\x00"
+        req_frame.destination_address = b"\x00\x00\x00"
+        req_frame.source_device_type = b"\x00"
+        req_frame.source_address = int(2207298).to_bytes(3, byteorder="big")
 
-        data_field = EmliteData(5)
-        data_field.format = b'\x01'
-        data_field.object_id = b'\x60\x01\x00'  # get serial obj id
-        data_field.read_write = EmliteData.ReadWriteFlags.read
-        data_field.payload = bytes()
+        data_payload_len = 5
+        message_field = EmliteData.DefaultRec(data_payload_len)
+        message_field.object_id = b"\x60\x01\x00"  # get serial obj id
+        message_field.read_write = EmliteData.ReadWriteFlags.read
+        message_field.payload = bytes()
+
+        data_field = EmliteData(data_payload_len)
+        data_field.format = EmliteData.RecordFormat.default
+        data_field.message = message_field
 
         req_frame.data = data_field
 
@@ -66,22 +70,22 @@ class TestEmliteFrame(unittest.TestCase):
         frame_bytes_len = req_frame.frame_length + 1
 
         # Serialize once first to get bytes for checksum compute:
-        req_frame.crc16 = b'\x00\x00'
+        req_frame.crc16 = b"\x00\x00"
         _io = KaitaiStream(BytesIO(bytearray(frame_bytes_len)))
         req_frame._write(_io)
         frame_bytes_zero_checksum = _io.to_byte_array()
 
         # add checksum
         req_frame.crc16 = crc16(
-            frame_bytes_zero_checksum[1:frame_bytes_len-2]).to_bytes(2)
+            frame_bytes_zero_checksum[1 : frame_bytes_len - 2]
+        ).to_bytes(2)
 
         # compute final frame bytes
         _io = KaitaiStream(BytesIO(bytearray(frame_bytes_len)))
         req_frame._write(_io)
         frame_bytes = _io.to_byte_array()
 
-        self.assertEqual(frame_bytes.hex(),
-                         '7e11000000000021ae42050160010000c02f')
+        self.assertEqual(frame_bytes.hex(), "7e11000000000021ae42050160010000c02f")
 
     # def test_print_frame(self):
     #     # frame_hex = "7E2501FFFFFFC01234560101FFC8030137313436363339343632313538393136313032300830"


### PR DESCRIPTION
EMOP: handle profile log messages:
- update emlite_data to handle format 3 and 4 (profile logs)
- update emlite_frame to handle profile log messages when determining the frame length
- add client profile 1 and 2 calls

Changes here are able to send profile log requests and get back raw profile log responses. The shape of the those responses has not yet been defined and so unpacking those is not yet supported..