### PR TITLE
fix unexpected events on sync of new meter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simt-emlite"
-version = "0.22.8"
+version = "0.22.9"
 description = "API and CLI for communicating with the Emlite meters via EMOP"
 authors = [{ name = "Chris Hatch", email = "chris@cepro.energy" }]
 requires-python = ">=3.13,<4.0"

--- a/simt_emlite/jobs/meter_sync_all.py
+++ b/simt_emlite/jobs/meter_sync_all.py
@@ -60,7 +60,6 @@ class MeterSyncAllJob:
         try:
             containers_api = None
             if is_single_meter_app:
-                print("get_instance")
                 containers_api = get_instance(
                     is_single_meter_app=is_single_meter_app,
                     serial=serial,
@@ -68,8 +67,6 @@ class MeterSyncAllJob:
                 )
             else:
                 containers_api = get_instance(esco=esco)
-
-            print("got_instance")
 
             mediator_address = containers_api.mediator_address(meter_id, serial)
             if mediator_address is None:

--- a/simt_emlite/orchestrate/adapter/fly_adapter.py
+++ b/simt_emlite/orchestrate/adapter/fly_adapter.py
@@ -93,16 +93,19 @@ class FlyAdapter(BaseAdapter):
         status_filter: ContainerState | None = None,
     ) -> List[Container]:
         machines = self.api.list(self.fly_app, region=self.region)
+        logger.info(f"machines0 {machines}")
 
         if "error" in machines:
             logger.warning(f"failed to get machines {machines}", fly_app=self.fly_app)
             return []
 
         machines = list(filter(lambda m: m["name"].startswith("mediator-"), machines))
+        logger.info(f"machines {machines}")
 
         # machines in an odd state will have no config - they are in the
         #   machines listing but don't really exist (have asked fly about this)
         machines = list(filter(lambda m: m["config"] is not None, machines))
+        logger.info(f"machines2 {machines}")
 
         if metadata_filter:
             logger.debug(f"metadata filter [{metadata_filter}]")

--- a/simt_emlite/sync/syncer_event_log.py
+++ b/simt_emlite/sync/syncer_event_log.py
@@ -98,7 +98,13 @@ class SyncerEventLog(SyncerBase):
             )
 
             response = (
-                self.supabase.table("meter_event_log").insert(insert_recs).execute()
+                self.supabase.table("meter_event_log")
+                .upsert(
+                    insert_recs,
+                    on_conflict="meter_id,timestamp,event_type",
+                    ignore_duplicates=True,
+                )
+                .execute()
             )
             logger.info("supabase insert response", response=response)
 


### PR DESCRIPTION
syncing a new meter seeing 2 unexpected cases:
- event id's (types) of zero
- timestamp / event id duplicates

previously we'd said these are not allowed and I still think that is right. these event logs are from > 20 years ago and it appears the meter has just not been initialised correctly. somehow these events sit in the memory.

so the PR filters these out of inserts in the event log in the database.